### PR TITLE
update form/sheet URLs to use env vars

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,8 @@
+# or PUBLIC_MAP_ATTRIBUTION="&copy; <a href='http://www.openstreetmap.org/copyright' target='_blank'>OpenStreetMap</a> contributors"
 PUBLIC_MAP_ATTRIBUTION="Map &copy; <a href='https://www.thunderforest.com' target='_blank'>Thunderforest</a>, Data &copy; <a href='http://www.openstreetmap.org/copyright' target='_blank'>OpenStreetMap</a> contributors"
-# or just PUBLIC_MAP_ATTRIBUTION="&copy; <a href='http://www.openstreetmap.org/copyright' target='_blank'>OpenStreetMap</a> contributors"
+PUBLIC_FORM_REPORT="https://docs.google.com/forms/d/e/1FAIpQLSeQPKKgqx_tR4Yp9kNynRpriRlsPerugbziuBVWjTHAdff_Kw/viewform"
+PUBLIC_FORM_REQUEST="https://docs.google.com/forms/d/e/1FAIpQLSeoh_bZOndFPvSpkW468EsgudlD8OeXM2h7TpL_yCX9HKjH3A/viewform"
+PUBLIC_SCRIPT_UPKEEP="https://script.google.com/macros/s/AKfycbxu9WHMmJUFORzjYkIPSB0vgVx2kfrA8--Rf8dAdkia/dev/upkeep"
+# `VITE_` prefix is needed since `astro.config.ts` uses these variables, otherwise the astro-specific `PUBLIC_` prefix would suffice.
+VITE_SHEET_BENCHES="https://docs.google.com/spreadsheets/d/e/2PACX-1vTWDmQyR76rCXXmwltSZaa_5iCi-z6IOqkfNkjc52e713Rc5kfF7mDZuMxghsp-nJlAdskl-IBBbhzN/pub?gid=1711079204&single=true&output=csv"
+VITE_SHEET_NEWS="https://docs.google.com/spreadsheets/d/e/2PACX-1vTWDmQyR76rCXXmwltSZaa_5iCi-z6IOqkfNkjc52e713Rc5kfF7mDZuMxghsp-nJlAdskl-IBBbhzN/pub?gid=6743625&single=true&output=csv"

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'astro/config';
 import cloudflare from '@astrojs/cloudflare';
 import sitemap from '@astrojs/sitemap';
 import mdx from '@astrojs/mdx';
-import { SITES } from './src/data';
+import { getSites } from './src/data';
 import remarkSectionize from 'remark-sectionize';
 import remarkDetailize from './detailize.mjs';
 import remarkLiftCaptions from './lift-captions.mjs';
@@ -33,7 +33,7 @@ export default defineConfig({
     '/map_embed': '/map',
     '/guide': '/guides',
     '/guide/[..._]': '/guides',
-    ...Object.fromEntries((await SITES).flatMap(({ id, muni, act, ggt, vta }) => {
+    ...Object.fromEntries((await getSites()).flatMap(({ id, muni, act, ggt, vta }) => {
       return [
         muni, act, ggt, vta
       ].filter(stopId => stopId).map(stopId => ['/' + stopId, '/' + id])

--- a/src/components/BenchMap.astro
+++ b/src/components/BenchMap.astro
@@ -1,5 +1,5 @@
 ---
-import { SITES } from "../data";
+import { getSites } from "../data";
 
 interface Props {
   highlightSiteId?: number;
@@ -9,7 +9,7 @@ interface Props {
 const { highlightSiteId } = Astro.props;
 const height = Astro.props.height || "600px";
 
-const sites = await SITES;
+const sites = await getSites();
 ---
 
 <bench-map data-sites={JSON.stringify(sites)} data-highlight={highlightSiteId}>

--- a/src/data.ts
+++ b/src/data.ts
@@ -27,9 +27,9 @@ export interface News {
   description: string | null,
 }
 
-export const SITES: Promise<Site[]> = (async () => {
-  const SHEETS_DB_BENCHES = "https://docs.google.com/spreadsheets/d/e/2PACX-1vTWDmQyR76rCXXmwltSZaa_5iCi-z6IOqkfNkjc52e713Rc5kfF7mDZuMxghsp-nJlAdskl-IBBbhzN/pub?gid=1711079204&single=true&output=csv";
-  const res = await fetch(SHEETS_DB_BENCHES);
+let SITES: Promise<Site[]> | null = null;
+export const getSites: () => Promise<Site[]> = () => SITES = SITES ?? (async () => {
+  const res = await fetch(import.meta.env.VITE_SHEET_BENCHES);
   const [head, ...rows] = parseCsv(await res.text());
   const headIdx = Object.fromEntries(head!.map((col, i) => [col.toUpperCase().replace(/[^ A-Z0-9]/g, ''), i]));
 
@@ -95,11 +95,12 @@ export const SITES: Promise<Site[]> = (async () => {
 })();
 
 export const getSite = async (sid: number) =>
-  (await SITES).find(site => sid === site.id);
+  (await getSites()).find(site => sid === site.id);
 
-export const NEWS: Promise<News[]> = (async () => {
-  const SHEETS_DB_NEWS = "https://docs.google.com/spreadsheets/d/e/2PACX-1vTWDmQyR76rCXXmwltSZaa_5iCi-z6IOqkfNkjc52e713Rc5kfF7mDZuMxghsp-nJlAdskl-IBBbhzN/pub?gid=6743625&single=true&output=csv";
-  const res = await fetch(SHEETS_DB_NEWS);
+
+let NEWS: Promise<News[]> | null = null;
+export const getNews: () => Promise<News[]> = () => NEWS = NEWS ?? (async () => {
+  const res = await fetch(import.meta.env.VITE_SHEET_NEWS);
   const [head, ...rows] = parseCsv(await res.text());
   const headIdx = Object.fromEntries(head!.map((col, i) => [col.toUpperCase(), i]));
   return rows

--- a/src/data.ts
+++ b/src/data.ts
@@ -27,8 +27,8 @@ export interface News {
   description: string | null,
 }
 
-let SITES: Promise<Site[]> | null = null;
-export const getSites: () => Promise<Site[]> = () => SITES = SITES ?? (async () => {
+let cachedSites: Promise<Site[]> | null = null;
+export const getSites: () => Promise<Site[]> = () => cachedSites = cachedSites ?? (async () => {
   const res = await fetch(import.meta.env.VITE_SHEET_BENCHES);
   const [head, ...rows] = parseCsv(await res.text());
   const headIdx = Object.fromEntries(head!.map((col, i) => [col.toUpperCase().replace(/[^ A-Z0-9]/g, ''), i]));
@@ -98,8 +98,8 @@ export const getSite = async (sid: number) =>
   (await getSites()).find(site => sid === site.id);
 
 
-let NEWS: Promise<News[]> | null = null;
-export const getNews: () => Promise<News[]> = () => NEWS = NEWS ?? (async () => {
+let cachedNews: Promise<News[]> | null = null;
+export const getNews: () => Promise<News[]> = () => cachedNews = cachedNews ?? (async () => {
   const res = await fetch(import.meta.env.VITE_SHEET_NEWS);
   const [head, ...rows] = parseCsv(await res.text());
   const headIdx = Object.fromEntries(head!.map((col, i) => [col.toUpperCase(), i]));

--- a/src/pages/[siteId].astro
+++ b/src/pages/[siteId].astro
@@ -2,13 +2,13 @@
 import { Image } from "astro:assets";
 import Page from "../layouts/Page.astro";
 import type { GetStaticPaths } from "astro";
-import { SITES, getSite } from "../data";
+import { getSites, getSite } from "../data";
 import BenchMap from "../components/BenchMap.astro";
 
 export const prerender = true;
 export const getStaticPaths = (async () => {
-  return (await SITES)
-    .map((site) => site.id)
+  return (await getSites())
+    .map(({ id }) => id)
     .filter((siteId) => null != siteId)
     .map((siteId) => ({
       params: {
@@ -156,7 +156,7 @@ const site = (await getSite(+siteId))!;
   <BenchMap highlightSiteId={siteId} />
   <h2>Admin</h2>
   <p>
-    <a href={`https://script.google.com/macros/s/AKfycbxu9WHMmJUFORzjYkIPSB0vgVx2kfrA8--Rf8dAdkia/dev/upkeep?siteId=${siteId}`}>Submit Upkeep (Admin Only)</a>
+    <a href={`${import.meta.env.PUBLIC_SCRIPT_UPKEEP}?siteId=${siteId}`}>Submit Upkeep (Admin Only)</a>
   </p>
   <details>
     <summary>Raw Data</summary>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,12 +2,12 @@
 import Layout from "../layouts/Layout.astro";
 import BenchMap from "../components/BenchMap.astro";
 import LinkPreview from "../components/LinkPreview.astro";
-import { NEWS } from "../data";
+import { getNews } from "../data";
 import { SHORT_NAME } from "../vars";
 
 export const prerender = true;
 
-const FIRST_NEWS = (await NEWS)[0]!;
+const FIRST_NEWS = (await getNews())[0]!;
 ---
 
 <Layout>

--- a/src/pages/news.astro
+++ b/src/pages/news.astro
@@ -1,11 +1,11 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import LinkPreview from "../components/LinkPreview.astro";
-import { NEWS } from "../data";
+import { getNews } from "../data";
 
 export const prerender = true;
 
-const NEWS_ALL = await NEWS;
+const NEWS_ALL = await getNews();
 ---
 
 <Layout title="News">

--- a/src/pages/report.astro
+++ b/src/pages/report.astro
@@ -26,9 +26,7 @@ export const prerender = true;
     loc?: string | null,
     siteId?: `${number}` | null,
   ): string {
-    const url = new URL(
-      "https://docs.google.com/forms/d/e/1FAIpQLSeQPKKgqx_tR4Yp9kNynRpriRlsPerugbziuBVWjTHAdff_Kw/viewform",
-    );
+    const url = new URL(import.meta.env.PUBLIC_FORM_REPORT);
     if (embedded) url.searchParams.append("embedded", "true");
     if (null != loc) url.searchParams.append("entry.1051599017", loc);
     if (null != siteId) url.searchParams.append("entry.757375298", `${siteId}`);

--- a/src/pages/request.astro
+++ b/src/pages/request.astro
@@ -22,9 +22,7 @@ export const prerender = true;
 
 <script>
   function formUrl(embedded?: boolean, loc?: string | null): string {
-    const url = new URL(
-      "https://docs.google.com/forms/d/e/1FAIpQLSeoh_bZOndFPvSpkW468EsgudlD8OeXM2h7TpL_yCX9HKjH3A/viewform",
-    );
+    const url = new URL(import.meta.env.PUBLIC_FORM_REQUEST);
     if (embedded) url.searchParams.append("embedded", "true");
     if (null != loc) url.searchParams.append("entry.1000004130", loc);
     return url.toString();


### PR DESCRIPTION
Changes `data.ts` to fetch the sheets URLs lazily instead of eagerly, so they will only be fetched server-side